### PR TITLE
Removed excess of import commands

### DIFF
--- a/Tutorials/publish_subscribe.asciidoc
+++ b/Tutorials/publish_subscribe.asciidoc
@@ -18,10 +18,6 @@ pn = pubnub.NewPubNub(config)
 [source, go]
 .PUBLISHING AND SUBSCRIBING TO A CHANNEL
 ----
-import (
-    pubnub "github.com/pubnub/go"
-)
-
 pn.Subscribe(&pubnub.SubscribeOperation{
     Channels: []string{"my-channel"}, // subscribe to channels
 })
@@ -95,10 +91,6 @@ pn.Subscribe(&pubnub.SubscribeOperation{
 [source, go]
 .UNSUBSCRIBING FROM A CHANNEL
 ----
-import (
-    pubnub "github.com/pubnub/go"
-)
-
 pn.Unsubscribe(&pubnub.UnsubscribeOperation{
     Channels: []string{"my-channel"},
 })


### PR DESCRIPTION
As per my knowledge import commands only be needed where we are initializing the keys and applying configuration Otherwise we doesn't need to add it in all the snippets it looks confusing to users.