### PR TITLE
Removed excess of import commands

### DIFF
--- a/Design Patterns/advanced_channel_groups.asciidoc
+++ b/Design Patterns/advanced_channel_groups.asciidoc
@@ -140,10 +140,6 @@ fmt.Println("Channel added to channel group")
 
 [source, go]
 ----
-import (
-    pubnub "github.com/pubnub/go"
-)
-
 // Get the List of Friends
 listChannelsRes, _, err := pn.ListChannelsInChannelGroup().
     ChannelGroup("cg-user-a-friends").
@@ -193,10 +189,6 @@ pn.Subscribe(&pubnub.SubscribeOperation{
 
 [source, go]
 ----
-import (
-    pubnub "github.com/pubnub/go"
-)
-
 listener := pubnub.NewListener()
 
 go func() {


### PR DESCRIPTION
As per my knowledge import commands only be needed where we are initializing the keys and applying configuration Otherwise we doesn't need to add it in all the snippets it looks confusing to users.